### PR TITLE
Removed the lattitude and longitude from the frontend homepage table …

### DIFF
--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -33,14 +33,6 @@ export default function DiningCommonsTable({ commons, date }) {
       accessor: "hasTakeoutMeal",
       Cell: ({ value }) => (value ? "✅" : "❌"),
     },
-    {
-      Header: "Latitude",
-      accessor: "latitude",
-    },
-    {
-      Header: "Longitude",
-      accessor: "longitude",
-    },
   ];
 
   const displayedColumns = columns;

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -20,8 +20,6 @@ describe("DiningCommonsTable tests", () => {
     "Has Dining Cam",
     "Has Sack Meal",
     "Has Takeout Meal",
-    "Latitude",
-    "Longitude",
   ];
   const expectedFields = [
     "code",
@@ -29,8 +27,6 @@ describe("DiningCommonsTable tests", () => {
     "hasDiningCam",
     "hasSackMeal",
     "hasTakeoutMeal",
-    "latitude",
-    "longitude",
   ];
   const testId = "DiningCommonsTable";
   const date = new Date("2025-03-11").toISOString().split("T")[0];
@@ -216,8 +212,6 @@ describe("DiningCommonsTable tests", () => {
       "Has Dining Cam",
       "Has Sack Meal",
       "Has Takeout Meal",
-      "Latitude",
-      "Longitude",
     ];
     const expectedFields = [
       "code",
@@ -225,8 +219,6 @@ describe("DiningCommonsTable tests", () => {
       "hasDiningCam",
       "hasSackMeal",
       "hasTakeoutMeal",
-      "latitude",
-      "longitude",
     ];
     const testId = "DiningCommonsTable";
 
@@ -266,8 +258,6 @@ describe("DiningCommonsTable tests", () => {
       "Has Dining Cam",
       "Has Sack Meal",
       "Has Takeout Meal",
-      "Latitude",
-      "Longitude",
     ];
     const expectedFields = [
       "code",
@@ -275,8 +265,6 @@ describe("DiningCommonsTable tests", () => {
       "hasDiningCam",
       "hasSackMeal",
       "hasTakeoutMeal",
-      "latitude",
-      "longitude",
     ];
     const testId = "DiningCommonsTable";
 


### PR DESCRIPTION
In this Pull Request, I removed the latitude and longitude page from the fronend diningcommons table and ensured that all the tests passed:

<img width="1512" alt="Screenshot 2025-05-20 at 10 30 52 PM" src="https://github.com/user-attachments/assets/ad5adc47-be45-43d3-a846-7bfec75c5f7b" />

Here's a dokku link to test: 
https://dining-dev-rbuneti.dokku-08.cs.ucsb.edu/